### PR TITLE
Use use_json_discriminator to simplify parsing of GeoJSON::Object

### DIFF
--- a/spec/object_spec.cr
+++ b/spec/object_spec.cr
@@ -1,0 +1,23 @@
+require "./spec_helper"
+
+describe GeoJSON::Object do
+  coordinates1 = [100.0, 0.0]
+  coordinates2 = [101.0, 1.0]
+
+  multi_point_json = {
+    "type"        => "MultiPoint",
+    "coordinates" => [coordinates1, coordinates2],
+  }.to_json
+
+  describe "json parser" do
+    it "parses json" do
+      object = GeoJSON::Object.from_json(multi_point_json)
+
+      multi_point = object.should be_a(GeoJSON::MultiPoint)
+      multi_point.type.should eq("MultiPoint")
+      multi_point.coordinates.should be_a(Array(GeoJSON::Coordinates))
+      multi_point[0].should be_a(GeoJSON::Coordinates)
+      multi_point[0].latitude.should eq(0.0)
+    end
+  end
+end

--- a/src/geo_json/object.cr
+++ b/src/geo_json/object.cr
@@ -20,119 +20,15 @@ module GeoJSON
     # All possible GeoJSON types.
     alias Type = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon
 
-    alias CoordinatesArray = Array(Float64) | Array(CoordinatesArray)
-
     abstract def type : String
 
-    def self.new(pull : JSON::PullParser)
-      object_type, coordinates = parse_object(pull)
-
-      return unless coordinates
-
-      create_object(object_type, coordinates)
-    end
-
-    private def self.parse_object(pull)
-      pull.read_begin_object
-
-      until pull.kind.end_object?
-        case pull.read_string
-        when "type"
-          object_type = pull.read_string
-        when "coordinates"
-          coordinates = recursive_array(pull)
-        else
-          pull.read_next
-        end
-      end
-
-      pull.read_end_object
-
-      {object_type, coordinates}
-    end
-
-    private def self.create_object(object_type, coordinates)
-      case object_type
-      when "Point"
-        point(coordinates)
-      when "MultiPoint"
-        multi_point(coordinates)
-      when "LineString"
-        line_string(coordinates)
-      when "MultiLineString"
-        multi_line_string(coordinates)
-      when "Polygon"
-        polygon(coordinates)
-      when "MultiPolygon"
-        multi_polygon(coordinates)
-      else
-        nil
-      end
-    end
-
-    # I am not sure why this works but it fixes the problem.
-    # You are not meant to understand this.
-    private def self.recursive_array(pull)
-      ary = [] of CoordinatesArray
-      coordinates = [] of Float64
-
-      pull.read_begin_array
-
-      until pull.kind.end_array?
-        if pull.kind.begin_array?
-          ary << recursive_array(pull)
-        elsif pull.kind.float?
-          coordinates << pull.read_float
-        end
-      end
-
-      pull.read_end_array
-
-      ary.empty? ? coordinates : ary
-    end
-
-    private def self.point(coordinates) : Point
-      Point.new(coordinates.as(Array(Float64)))
-    end
-
-    private def self.multi_point(coordinates) : MultiPoint
-      points = coordinates.map do |point|
-        point(point)
-      end
-
-      GeoJSON::MultiPoint.new(points)
-    end
-
-    private def self.line_string(coordinates) : LineString
-      coordinates = coordinates.map { |point| point.as(Array(Float64)).map(&.to_f) }
-
-      GeoJSON::LineString.new(coordinates)
-    end
-
-    private def self.multi_line_string(coordinates) : MultiLineString
-      line_strings = coordinates.map do |line_string|
-        line_string(line_string.as(Array(CoordinatesArray)))
-      end
-
-      GeoJSON::MultiLineString.new(line_strings)
-    end
-
-    private def self.polygon(coordinates) : Polygon
-      rings = coordinates.map do |ring|
-        ring.as(Array(CoordinatesArray)).map do |point|
-          point.as(Array(Float64)).map(&.to_f)
-        end
-      end
-
-      GeoJSON::Polygon.new(rings)
-    end
-
-    private def self.multi_polygon(coordinates) : MultiPolygon
-      polygons = coordinates.map do |polygon|
-        polygon(polygon.as(Array(CoordinatesArray)))
-      end
-
-      GeoJSON::MultiPolygon.new(polygons)
-    end
+    use_json_discriminator "type", {
+      Point:           Point,
+      MultiPoint:      MultiPoint,
+      LineString:      LineString,
+      MultiLineString: MultiLineString,
+      Polygon:         Polygon,
+      MultiPolygon:    MultiPolygon,
+    }
   end
 end


### PR DESCRIPTION
Some release ago Crystal added a `use_json_discriminator` macro to the JSON library (and a similar one for YAML). This allows you to define different objects to parse depending on the value of a field.

This PR does that. It essentially removes a lot of code with a single line that does exactly what was there before, only all the code is generated with the macro.

I also added a small test to prove it works.